### PR TITLE
fix 2 max_token issues

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -45,7 +45,7 @@ export const getChatCompletion = async (
     body: JSON.stringify({
       messages,
       ...config,
-      max_tokens: undefined,
+      max_tokens: config.max_tokens,
     }),
   });
   if (!response.ok) throw new Error(await response.text());
@@ -97,7 +97,7 @@ export const getChatCompletionStream = async (
     body: JSON.stringify({
       messages,
       ...config,
-      max_tokens: undefined,
+      max_tokens: config.max_tokens,
       stream: true,
     }),
   });

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,6 +1,8 @@
 import { ShareGPTSubmitBodyInterface } from '@type/api';
 import { ConfigInterface, MessageInterface } from '@type/chat';
 import { isAzureEndpoint, isOpenRouterEndpoint } from '@utils/api';
+import { modelMaxToken } from '@constants/chat';
+import countTokens from '@utils/messageUtils';
 
 export const getChatCompletion = async (
   endpoint: string,
@@ -14,7 +16,6 @@ export const getChatCompletion = async (
     ...customHeaders,
   };
   if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
-
   if (isAzureEndpoint(endpoint) && apiKey) {
     headers['api-key'] = apiKey;
 
@@ -39,13 +40,16 @@ export const getChatCompletion = async (
       headers['X-Title'] = "BetterChatGPT | OpenRouterAI";
   }
 
+  const tokenCount = countTokens(messages, config.model);
+  const maxTokens = Math.min(config.max_tokens, modelMaxToken[config.model] - tokenCount);
+
   const response = await fetch(endpoint, {
     method: 'POST',
     headers,
     body: JSON.stringify({
       messages,
       ...config,
-      max_tokens: config.max_tokens,
+      max_tokens: maxTokens,
     }),
   });
   if (!response.ok) throw new Error(await response.text());
@@ -66,7 +70,6 @@ export const getChatCompletionStream = async (
     ...customHeaders,
   };
   if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
-
   if (isAzureEndpoint(endpoint) && apiKey) {
     headers['api-key'] = apiKey;
 
@@ -91,13 +94,16 @@ export const getChatCompletionStream = async (
       headers['X-Title'] = "BetterChatGPT | OpenRouterAI";
   }
 
+  const tokenCount = countTokens(messages, config.model);
+  const maxTokens = Math.min(config.max_tokens, modelMaxToken[config.model] - tokenCount)-1;
+
   const response = await fetch(endpoint, {
     method: 'POST',
     headers,
     body: JSON.stringify({
       messages,
       ...config,
-      max_tokens: config.max_tokens,
+      max_tokens: maxTokens,
       stream: true,
     }),
   });

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -144,6 +144,15 @@ export const _defaultChatConfig: ConfigInterface = {
   frequency_penalty: 0,
 };
 
+export const _generateTitleConfig:ConfigInterface = {
+  model: defaultModel,
+  max_tokens: 200,//Only 6 words in title according to the prompt
+  temperature: 0,//for stable titles
+  presence_penalty: 0,
+  top_p: 1,
+  frequency_penalty: 0,
+};
+
 export const generateDefaultChat = (
   title?: string,
   folder?: string

--- a/src/hooks/useSubmit.ts
+++ b/src/hooks/useSubmit.ts
@@ -6,6 +6,7 @@ import { getChatCompletion, getChatCompletionStream } from '@api/api';
 import { parseEventSource } from '@api/helper';
 import { limitMessageTokens, updateTotalTokenUsed } from '@utils/messageUtils';
 import { _defaultChatConfig } from '@constants/chat';
+import { _generateTitleConfig } from '@constants/chat';
 import { officialAPIEndpoint } from '@constants/auth';
 
 const useSubmit = () => {
@@ -34,14 +35,14 @@ const useSubmit = () => {
         data = await getChatCompletion(
           useStore.getState().apiEndpoint,
           message,
-          _defaultChatConfig
+          _generateTitleConfig
         );
       } else if (apiKey) {
         // own apikey
         data = await getChatCompletion(
           useStore.getState().apiEndpoint,
           message,
-          _defaultChatConfig,
+          _generateTitleConfig,
           apiKey
         );
       }
@@ -194,7 +195,7 @@ const useSubmit = () => {
 
         // update tokens used for generating title
         if (countTotalTokens) {
-          const model = _defaultChatConfig.model;
+          const model = _generateTitleConfig.model;
           updateTotalTokenUsed(model, [message], {
             role: 'assistant',
             content: title,


### PR DESCRIPTION
1. created a new `generateTitleConfig` with a smaller `max_tokens` （200，but could be lower) value to avoid failing to generate the chat title in the first round of the conversation;.
2. use `const maxTokens = Math.min(config.max_tokens, modelMaxToken[config.model] - tokenCount)-1;` to make sure that `max_tokens` in the request is always valid

edit: there's no need to add a new config to fix the max_tokens issue as it has been fixed in api.ts，but just keep the  temp=0 in the new config lol ( I like temp 0 😀) )