### PR TITLE
disable message context control which uses max_tokens

### DIFF
--- a/src/hooks/useSubmit.ts
+++ b/src/hooks/useSubmit.ts
@@ -71,11 +71,7 @@ const useSubmit = () => {
       if (chats[currentChatIndex].messages.length === 0)
         throw new Error('No messages submitted!');
 
-      const messages = limitMessageTokens(
-        chats[currentChatIndex].messages,
-        chats[currentChatIndex].config.max_tokens,
-        chats[currentChatIndex].config.model
-      );
+      const messages = chats[currentChatIndex].messages
       if (messages.length === 0) throw new Error('Message exceed max token!');
 
       // no api key (free)


### PR DESCRIPTION
the oringin repo use `max_tokens` to limit the message context. it's not a correct way to use that parameter so i disable it